### PR TITLE
Add cargo keywords+categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT"
 repository = "https://github.com/oconnor663/shared_child.rs"
 documentation = "https://docs.rs/shared_child"
 description = "a library for using child processes from multiple threads"
+keywords = ["command", "process", "child", "clone", "wait"]
+categories = ["os"]
 
 [dependencies]
 libc = "^0.2.20"


### PR DESCRIPTION
Increase discoverability by adding keywords and a category.

I'll yank all releases of `clonablechild` since it has problems this crate does not have. But would be nice if this crate was at least as easy to find first :)