### PR TITLE
Allow to construct from std::process::Child

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,19 @@ pub struct SharedChild {
 }
 
 impl SharedChild {
-    /// Spawn a new `SharedChild` from a `std::process::Command`.
-    pub fn spawn(command: &mut Command) -> io::Result<SharedChild> {
-        let child = command.spawn()?;
-        Ok(SharedChild {
+    /// Create `SharedChild` from a `std::process::Child`
+    pub fn new(child: Child) -> Self {
+        Self {
             child: Mutex::new(child),
             state_lock: Mutex::new(NotWaiting),
             state_condvar: Condvar::new(),
-        })
+        }
+    }
+
+    /// Spawn a new `SharedChild` from a `std::process::Command`.
+    pub fn spawn(command: &mut Command) -> io::Result<SharedChild> {
+        let child = command.spawn()?;
+        Ok(Self::new(child))
     }
 
     /// Return the child process ID.


### PR DESCRIPTION
This PR allow me to interact with a long running process's stdin and stdout, **more than one time,** without deadlock. This is also a new solution to solve #18. I found using os_pipe will get into deadlock in my case.

    let child = command
            .new_process_group()
            .stdin(Stdio::piped())
            .stdout(Stdio::piped())
            .spawn()?;
    let stdout = child.stdout.take().unwrap();
    let stdin = child.stdin.take().unwrap();
    let handler = SharedChild::new(child);
    # write stdin here
    # read result from stdout


sample uses in my repo:
https://github.com/ybyygu/vasp-tools/blob/bf0d1c8e79c88b8ba3f47f2029ee2e55a736a3c1/src/session.rs#L356
